### PR TITLE
Add pipeline logging helper and final log function

### DIFF
--- a/automation/agents/correlation_eda.py
+++ b/automation/agents/correlation_eda.py
@@ -11,5 +11,5 @@ def run(state: PipelineState) -> PipelineState:
         df[state.target] = df[state.target].astype('category').cat.codes
         corr = df.corr()[state.target].drop(state.target).abs().sort_values(ascending=False)
     top = corr.head(5)
-    state.log.append(f"CorrelationEDA: top correlated features: {', '.join(top.index)}")
+    state.append_log(f"CorrelationEDA: top correlated features: {', '.join(top.index)}")
     return state

--- a/automation/agents/feature_ideation.py
+++ b/automation/agents/feature_ideation.py
@@ -6,6 +6,6 @@ def run(state: PipelineState) -> PipelineState:
     if len(numeric_cols) >= 2:
         feat_name = f"{numeric_cols[0]}_over_{numeric_cols[1]}"
         formula = f"{numeric_cols[0]} / ({numeric_cols[1]} + 1e-6)"
-        state.log.append(f"FeatureIdeation: proposing {feat_name} = {formula}")
+        state.append_log(f"FeatureIdeation: proposing {feat_name} = {formula}")
         state.features.append(feat_name)
     return state

--- a/automation/agents/feature_implementation.py
+++ b/automation/agents/feature_implementation.py
@@ -8,6 +8,6 @@ def run(state: PipelineState) -> PipelineState:
             num1, num2 = feat.split('_over_')
             if num1 in df.columns and num2 in df.columns:
                 df[feat] = df[num1] / (df[num2] + 1e-6)
-                state.log.append(f"FeatureImplementation: created {feat}")
+                state.append_log(f"FeatureImplementation: created {feat}")
     state.df = df
     return state

--- a/automation/agents/feature_reduction.py
+++ b/automation/agents/feature_reduction.py
@@ -13,5 +13,7 @@ def run(state: PipelineState) -> PipelineState:
         state.df = df[[state.target]].join(
             pd.DataFrame(components, columns=comp_cols, index=df.index)
         )
-        state.log.append(f"FeatureReduction: applied PCA to {len(feature_cols)} features -> {len(comp_cols)} components")
+        state.append_log(
+            f"FeatureReduction: applied PCA to {len(feature_cols)} features -> {len(comp_cols)} components"
+        )
     return state

--- a/automation/agents/feature_selection.py
+++ b/automation/agents/feature_selection.py
@@ -17,5 +17,5 @@ def run(state: PipelineState) -> PipelineState:
         model = LinearRegression()
         model.fit(X_train, y_train)
         score = r2_score(y_test, model.predict(X_test))
-    state.log.append(f"FeatureSelection: baseline score {score:.4f}")
+    state.append_log(f"FeatureSelection: baseline score {score:.4f}")
     return state

--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -14,11 +14,11 @@ def run(state: PipelineState) -> PipelineState:
         model.fit(X_train, y_train)
         preds = model.predict(X_test)
         report = classification_report(y_test, preds)
-        state.log.append(f"ModelEvaluation:\n{report}")
+        state.append_log(f"ModelEvaluation:\n{report}")
     else:
         model = LinearRegression()
         model.fit(X_train, y_train)
         preds = model.predict(X_test)
         mse = mean_squared_error(y_test, preds)
-        state.log.append(f"ModelEvaluation: mse={mse:.4f}")
+        state.append_log(f"ModelEvaluation: mse={mse:.4f}")
     return state

--- a/automation/agents/model_training.py
+++ b/automation/agents/model_training.py
@@ -13,10 +13,10 @@ def run(state: PipelineState) -> PipelineState:
         model = LogisticRegression(max_iter=200)
         model.fit(X_train, y_train)
         score = accuracy_score(y_test, model.predict(X_test))
-        state.log.append(f"ModelTraining: LogisticRegression accuracy={score:.4f}")
+        state.append_log(f"ModelTraining: LogisticRegression accuracy={score:.4f}")
     else:
         model = LinearRegression()
         model.fit(X_train, y_train)
         score = r2_score(y_test, model.predict(X_test))
-        state.log.append(f"ModelTraining: LinearRegression r2={score:.4f}")
+        state.append_log(f"ModelTraining: LinearRegression r2={score:.4f}")
     return state

--- a/automation/agents/preprocessing.py
+++ b/automation/agents/preprocessing.py
@@ -11,6 +11,6 @@ def run(state: PipelineState) -> PipelineState:
             else:
                 fill_value = df[col].mean()
             df[col] = df[col].fillna(fill_value)
-            state.log.append(f"Preprocessing: filled missing values in {col} with {fill_value}")
+            state.append_log(f"Preprocessing: filled missing values in {col} with {fill_value}")
     state.df = df
     return state

--- a/automation/agents/task_identification.py
+++ b/automation/agents/task_identification.py
@@ -7,5 +7,5 @@ def run(state: PipelineState) -> PipelineState:
         state.task_type = 'classification'
     else:
         state.task_type = 'regression'
-    state.log.append(f"TaskIdentification: determined task_type={state.task_type}")
+    state.append_log(f"TaskIdentification: determined task_type={state.task_type}")
     return state

--- a/automation/pipeline.py
+++ b/automation/pipeline.py
@@ -10,6 +10,16 @@ def run_pipeline(csv_path: str, target: str):
     return state
 
 
+def compile_log(state: PipelineState) -> str:
+    """Return the pipeline log as a single formatted string."""
+    return "\n".join(state.log)
+
+
+def print_final_log(state: PipelineState) -> None:
+    """Print the collected pipeline log entries."""
+    print(compile_log(state))
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Run data science automation pipeline")
@@ -17,5 +27,4 @@ if __name__ == "__main__":
     parser.add_argument("target", help="Target column name")
     args = parser.parse_args()
     final_state = run_pipeline(args.csv, args.target)
-    for entry in final_state.log:
-        print(entry)
+    print_final_log(final_state)

--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -10,3 +10,7 @@ class PipelineState:
     iterate: bool = False
     log: List[str] = field(default_factory=list)
     features: List[str] = field(default_factory=list)
+
+    def append_log(self, message: str) -> None:
+        """Append a human-readable message to the pipeline log."""
+        self.log.append(str(message))


### PR DESCRIPTION
## Summary
- extend `PipelineState` with an `append_log` method
- update all agents to use the new method
- add utilities to compile and print logs in `pipeline.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m automation.pipeline test.csv target`

------
https://chatgpt.com/codex/tasks/task_e_6874e5c1a9e883238e04f44aced4e884