### PR TITLE
Add code tracking and early stopping

### DIFF
--- a/automation/agents/feature_reduction.py
+++ b/automation/agents/feature_reduction.py
@@ -36,6 +36,7 @@ def run(state: PipelineState) -> PipelineState:
     """Consult an LLM on PCA usage and apply if recommended."""
 
     df = state.df
+    stage_name = "feature_reduction"
     feature_cols = [c for c in df.columns if c != state.target]
     if not feature_cols:
         return state
@@ -102,4 +103,11 @@ def run(state: PipelineState) -> PipelineState:
         + reason
         + f" Applied PCA -> {len(comp_cols)} components"
     )
+    code_snippet = (
+        "pca = PCA(n_components=0.9)\n"
+        f"components = pca.fit_transform(df[{feature_cols!r}])\n"
+        "comp_cols = [f'pc{i+1}' for i in range(components.shape[1])]\n"
+        "df = df[[target]].join(pd.DataFrame(components, columns=comp_cols, index=df.index))"
+    )
+    state.append_code(stage_name, code_snippet)
     return state

--- a/automation/agents/feature_selection.py
+++ b/automation/agents/feature_selection.py
@@ -65,6 +65,7 @@ def run(state: PipelineState) -> PipelineState:
     """Evaluate new features incrementally and keep only beneficial ones."""
 
     df = state.df.copy()
+    stage_name = "feature_selection"
     new_feats = [f for f in state.features if f in df.columns]
 
     # Baseline without proposed features
@@ -148,5 +149,8 @@ def run(state: PipelineState) -> PipelineState:
     # Update dataframe and feature list
     state.df = current_df
     state.features = kept_features
+
+    code_snippet = f"df = df[['{state.target}'] + {kept_features!r}]"
+    state.append_code(stage_name, code_snippet)
 
     return state

--- a/automation/code_assembler.py
+++ b/automation/code_assembler.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+from automation.pipeline_state import PipelineState
+
+ORDER = [
+    "preprocessing",
+    "feature_implementation",
+    "feature_selection",
+    "feature_reduction",
+    "model_training",
+]
+
+
+def run(state: PipelineState) -> PipelineState:
+    """Assemble final pipeline code and save logs/history."""
+    os.makedirs("output", exist_ok=True)
+    os.makedirs("artifacts", exist_ok=True)
+
+    lines: list[str] = [
+        "import pandas as pd",
+        "from sklearn.model_selection import train_test_split",
+        "from sklearn.decomposition import PCA",
+        "from sklearn.linear_model import LogisticRegression, LinearRegression",
+        "from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor",
+        "from sklearn.svm import SVC, SVR",
+        "import joblib",
+    ]
+
+    for stage in ORDER:
+        for snippet in state.code_blocks.get(stage, []):
+            lines.append(snippet)
+
+    with open("pipeline.py", "w") as f:
+        f.write("\n\n".join(lines))
+
+    with open("output/logs.json", "w") as f:
+        json.dump(state.log, f, indent=2)
+
+    with open("output/history.json", "w") as f:
+        json.dump(state.iteration_history, f, indent=2)
+
+    report_lines = [
+        f"Best score: {state.best_score}",
+        f"Features: {state.features}",
+    ]
+    with open("output/report.txt", "w") as f:
+        f.write("\n".join(report_lines))
+
+    state.append_log("Final pipeline code assembled successfully")
+    return state

--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -10,7 +10,17 @@ class PipelineState:
     iterate: bool = False
     log: List[str] = field(default_factory=list)
     features: List[str] = field(default_factory=list)
+    code_blocks: dict[str, List[str]] = field(default_factory=dict)
+    iteration_history: List[dict] = field(default_factory=list)
+    best_score: Optional[float] = None
+    no_improve_rounds: int = 0
+    iteration: int = 0
+    max_iter: int = 0
 
     def append_log(self, message: str) -> None:
         """Append a human-readable message to the pipeline log."""
         self.log.append(str(message))
+
+    def append_code(self, stage: str, code: str) -> None:
+        """Store code snippets for later assembly."""
+        self.code_blocks.setdefault(stage, []).append(code)


### PR DESCRIPTION
## Summary
- extend `PipelineState` with new fields for code/history tracking and early stopping
- log executed code snippets in preprocessing, feature engineering, reduction and training
- implement early stopping and iteration history in model evaluation
- assemble final artifacts with new `code_assembler` agent
- update orchestrator for new logic and call code assembler at end

## Testing
- `python -m py_compile automation/pipeline_state.py automation/agents/*.py automation/code_assembler.py`

------
https://chatgpt.com/codex/tasks/task_e_68775f2e319483238229a6e1748c18b9