### PR TITLE
Remove heuristics and enforce LLM dependency

### DIFF
--- a/automation/pipeline.py
+++ b/automation/pipeline.py
@@ -2,6 +2,7 @@
 
 import argparse
 import pandas as pd
+import os
 
 from automation.pipeline_state import PipelineState
 from automation.agents import orchestrator
@@ -9,6 +10,9 @@ from automation.agents import orchestrator
 
 def run_pipeline(csv_path: str, target: str) -> PipelineState:
     """Load data, initialize :class:`PipelineState`, and run the orchestrator."""
+
+    if not os.getenv("OPENAI_API_KEY"):
+        raise RuntimeError("OPENAI_API_KEY environment variable is required")
 
     df = pd.read_csv(csv_path)
     state = PipelineState(df=df, target=target)


### PR DESCRIPTION
## Summary
- force OPENAI_API_KEY check before running pipeline
- make each agent fail when LLM calls fail or responses are malformed
- remove all heuristic fallbacks from preprocessing, feature engineering and modeling

## Testing
- `pip install -r requirements.txt`
- `python -m automation.pipeline iris.csv target` *(fails: LLM response missing decision for step 'feature_implementation')*

------
https://chatgpt.com/codex/tasks/task_e_6877843f53708323afc0321ec56cf8de