### PR TITLE
Add iteration tracking fields to PipelineState

### DIFF
--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -10,8 +10,8 @@ class PipelineState:
     iterate: bool = False
     log: List[str] = field(default_factory=list)
     features: List[str] = field(default_factory=list)
-    code_blocks: dict[str, List[str]] = field(default_factory=dict)
-    iteration_history: List[dict] = field(default_factory=list)
+    code_blocks: dict[str, list[str]] = field(default_factory=dict)
+    iteration_history: list[dict] = field(default_factory=list)
     best_score: Optional[float] = None
     no_improve_rounds: int = 0
     iteration: int = 0


### PR DESCRIPTION
## Summary
- use builtin generics for `code_blocks` and `iteration_history` fields
- keep helper methods for appending logs and code snippets

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall -q automation`

------
https://chatgpt.com/codex/tasks/task_e_6877a4408e888323ae95b55b9b33d25f