### PR TITLE
Refine iteration exit logic

### DIFF
--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -109,11 +109,9 @@ def run(state: PipelineState) -> PipelineState:
     else:
         state.no_improve_rounds += 1
 
-    improvement = 0 if prev_best is None else new_score - prev_best
     state.iterate = not (
-        state.no_improve_rounds >= 2
+        state.no_improve_rounds >= 5
         or state.iteration >= state.max_iter
-        or improvement < tol
     )
 
     log_msg = f"ModelEvaluation decision: iterate={state.iterate} - {reason}".strip()

--- a/automation/agents/orchestrator.py
+++ b/automation/agents/orchestrator.py
@@ -106,7 +106,7 @@ def _run_decided_steps(state: PipelineState) -> PipelineState:
     return state
 
 
-def run(state: PipelineState, max_iter: int = 3) -> PipelineState:
+def run(state: PipelineState, max_iter: int = 10) -> PipelineState:
     """Run the pipeline with LLM-guided orchestration and iteration."""
 
     state.best_score = None
@@ -115,12 +115,12 @@ def run(state: PipelineState, max_iter: int = 3) -> PipelineState:
 
     state = task_identification.run(state)
     state.iteration = 0
-    state = _run_decided_steps(state)
+    state.iterate = True
 
     while state.iterate and state.iteration < max_iter:
-        state.iteration += 1
         state.append_log(f"Orchestrator: starting iteration {state.iteration}")
         state = _run_decided_steps(state)
+        state.iteration += 1
 
     state = code_assembler.run(state)
     return state


### PR DESCRIPTION
## Summary
- raise orchestrator iteration limit to 10
- stop after 5 rounds without improvement in model evaluation

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile automation/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6877a97cf83883238a36d252ae1470da