### PR TITLE
Add pending code tracking

### DIFF
--- a/automation/agents/orchestrator.py
+++ b/automation/agents/orchestrator.py
@@ -113,6 +113,11 @@ def run(state: PipelineState, max_iter: int = 10) -> PipelineState:
     state.no_improve_rounds = 0
     state.max_iter = max_iter
 
+    # Initialize code tracking structures for each step
+    for step in STEP_AGENTS:
+        state.pending_code.setdefault(step, [])
+        state.code_blocks.setdefault(step, [])
+
     state = task_identification.run(state)
     state.iteration = 0
     state.iterate = True

--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -10,7 +10,9 @@ class PipelineState:
     iterate: bool = False
     log: List[str] = field(default_factory=list)
     features: List[str] = field(default_factory=list)
+    pending_code: dict[str, list[str]] = field(default_factory=dict)
     code_blocks: dict[str, list[str]] = field(default_factory=dict)
+    current_score: float | None = None
     iteration_history: list[dict] = field(default_factory=list)
     best_score: Optional[float] = None
     no_improve_rounds: int = 0
@@ -24,3 +26,7 @@ class PipelineState:
     def append_code(self, stage: str, code: str) -> None:
         """Store code snippets for later assembly."""
         self.code_blocks.setdefault(stage, []).append(code)
+
+    def append_pending_code(self, stage: str, code: str) -> None:
+        """Store code snippets awaiting validation or execution."""
+        self.pending_code.setdefault(stage, []).append(code)


### PR DESCRIPTION
## Summary
- extend `PipelineState` with `pending_code` and `current_score`
- add `append_pending_code` helper
- initialize `pending_code` and `code_blocks` for each step at orchestrator startup

## Testing
- `python -m py_compile automation/pipeline_state.py automation/agents/orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_6877b53a10bc83239d3ca21a54802e16