### PR TITLE
Refactor feature selection

### DIFF
--- a/automation/agents/feature_selection.py
+++ b/automation/agents/feature_selection.py
@@ -4,14 +4,7 @@ from __future__ import annotations
 
 import os
 from automation.pipeline_state import PipelineState
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import (
-    accuracy_score,
-    f1_score,
-    mean_squared_error,
-    r2_score,
-)
-from sklearn.linear_model import LogisticRegression, LinearRegression
+from . import model_evaluation
 
 
 def _query_llm(prompt: str) -> str:
@@ -37,28 +30,6 @@ def _query_llm(prompt: str) -> str:
         raise RuntimeError(f"LLM call failed: {exc}") from exc
 
 
-def _evaluate(df, target: str, task_type: str) -> dict[str, float]:
-    """Train a simple model and return relevant metrics."""
-
-    X = df.drop(columns=[target])
-    y = df[target]
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42
-    )
-    if task_type == "classification":
-        model = LogisticRegression(max_iter=200)
-        model.fit(X_train, y_train)
-        preds = model.predict(X_test)
-        acc = accuracy_score(y_test, preds)
-        f1 = f1_score(y_test, preds, average="weighted")
-        return {"accuracy": acc, "f1": f1}
-
-    model = LinearRegression()
-    model.fit(X_train, y_train)
-    preds = model.predict(X_test)
-    r2 = r2_score(y_test, preds)
-    rmse = mean_squared_error(y_test, preds, squared=False)
-    return {"r2": r2, "rmse": rmse}
 
 
 def run(state: PipelineState) -> PipelineState:
@@ -70,47 +41,28 @@ def run(state: PipelineState) -> PipelineState:
 
     # Baseline without proposed features
     baseline_df = df.drop(columns=new_feats, errors="ignore")
-    baseline_metrics = _evaluate(baseline_df, state.target, state.task_type)
-
-    if state.task_type == "classification":
-        state.append_log(
-            (
-                "FeatureSelection: baseline accuracy="
-                f"{baseline_metrics['accuracy']:.4f}, f1={baseline_metrics['f1']:.4f}"
-            )
-        )
-    else:
-        state.append_log(
-            (
-                "FeatureSelection: baseline r2="
-                f"{baseline_metrics['r2']:.4f}, rmse={baseline_metrics['rmse']:.4f}"
-            )
-        )
+    baseline_score = model_evaluation.compute_score(
+        baseline_df, state.target, state.task_type
+    )
+    state.append_log(
+        f"FeatureSelection: baseline score={baseline_score:.4f}"
+    )
 
     current_df = baseline_df
-    current_metrics = baseline_metrics
+    current_score = baseline_score
     kept_features: list[str] = []
 
     for feat in new_feats:
         trial_df = current_df.join(df[[feat]])
-        trial_metrics = _evaluate(trial_df, state.target, state.task_type)
-
-        if state.task_type == "classification":
-            delta_acc = trial_metrics["accuracy"] - current_metrics["accuracy"]
-            delta_f1 = trial_metrics["f1"] - current_metrics["f1"]
-            prompt = (
-                f"Baseline accuracy {current_metrics['accuracy']:.4f}, f1 {current_metrics['f1']:.4f}. "
-                f"After adding feature '{feat}', accuracy {trial_metrics['accuracy']:.4f}, f1 {trial_metrics['f1']:.4f}. "
-                "Should we keep this feature? Reply yes or no."
-            )
-        else:
-            delta_r2 = trial_metrics["r2"] - current_metrics["r2"]
-            delta_rmse = trial_metrics["rmse"] - current_metrics["rmse"]
-            prompt = (
-                f"Baseline r2 {current_metrics['r2']:.4f}, rmse {current_metrics['rmse']:.4f}. "
-                f"After adding feature '{feat}', r2 {trial_metrics['r2']:.4f}, rmse {trial_metrics['rmse']:.4f}. "
-                "Should we keep this feature? Reply yes or no."
-            )
+        trial_score = model_evaluation.compute_score(
+            trial_df, state.target, state.task_type
+        )
+        delta = trial_score - current_score
+        prompt = (
+            f"Baseline score {current_score:.4f}. "
+            f"After adding feature '{feat}', score {trial_score:.4f}. "
+            "Should we keep this feature? Reply yes or no."
+        )
 
         llm_decision = _query_llm(prompt)
         if not llm_decision:
@@ -120,30 +72,16 @@ def run(state: PipelineState) -> PipelineState:
         if keep:
             kept_features.append(feat)
             current_df = trial_df
-            current_metrics = trial_metrics
-            if state.task_type == "classification":
-                state.append_log(
-                    f"FeatureSelection: kept {feat} (+{delta_f1:.4f} f1, +{delta_acc:.4f} acc)"
-                )
-            else:
-                state.append_log(
-                    f"FeatureSelection: kept {feat} (+{delta_r2:.4f} r2, {delta_rmse:.4f} rmse change)"
-                )
+            current_score = trial_score
+            state.append_log(
+                f"FeatureSelection: kept {feat} ({delta:+.4f} score)"
+            )
         else:
-            if state.task_type == "classification":
-                state.append_log(
-                    f"FeatureSelection: dropped {feat} ({delta_f1:.4f} f1, {delta_acc:.4f} acc)"
-                )
-            else:
-                state.append_log(
-                    f"FeatureSelection: dropped {feat} ({delta_r2:.4f} r2, {delta_rmse:.4f} rmse change)"
-                )
+            state.append_log(
+                f"FeatureSelection: dropped {feat} ({delta:+.4f} score)"
+            )
 
-    # Update dataframe and feature list
-    state.df = current_df
-    state.features = kept_features
-
-    code_snippet = f"df = df[['{state.target}'] + {kept_features!r}]"
-    state.append_code(stage_name, code_snippet)
+    snippet = f"df = df[['{state.target}'] + {kept_features!r}]"
+    state.append_pending_code(stage_name, snippet)
 
     return state

--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -40,6 +40,26 @@ def _query_llm(prompt: str) -> str:
         raise RuntimeError(f"LLM call failed: {exc}") from exc
 
 
+def compute_score(df, target: str, task_type: str) -> float:
+    """Return a simple train/test score for the given dataset."""
+
+    X = df.drop(columns=[target])
+    y = df[target]
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    if task_type == "classification":
+        model = LogisticRegression(max_iter=200)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+        return accuracy_score(y_test, preds)
+
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    return r2_score(y_test, preds)
+
+
 def run(state: PipelineState) -> PipelineState:
     """Train a quick model, analyze metrics, and consult the LLM for advice."""
 


### PR DESCRIPTION
## Summary
- add `compute_score` helper in `model_evaluation`
- refactor `feature_selection` to use `compute_score`
- queue feature selection code snippet instead of mutating state

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q automation/agents`


------
https://chatgpt.com/codex/tasks/task_e_6877bcb015c08323a3030113ffeab992