### PR TITLE
Fix PCA condition and pin OpenAI

### DIFF
--- a/automation/agents/feature_reduction.py
+++ b/automation/agents/feature_reduction.py
@@ -60,14 +60,14 @@ def run(state: PipelineState) -> PipelineState:
 
     if apply_pca:
         state.append_log(f"FeatureReduction: PCA recommended - {reason}")
+        code_snippet = (
+            "pca = PCA(n_components=0.9)\n"
+            f"components = pca.fit_transform(df[{feature_cols!r}])\n"
+            "comp_cols = [f'pc{i+1}' for i in range(components.shape[1])]\n"
+            "df = df[[target]].join(pd.DataFrame(components, columns=comp_cols, index=df.index))"
+        )
+        state.append_pending_code(stage_name, code_snippet)
     else:
         state.append_log(f"FeatureReduction: skipped PCA - {reason}")
 
-    code_snippet = (
-        "pca = PCA(n_components=0.9)\n"
-        f"components = pca.fit_transform(df[{feature_cols!r}])\n"
-        "comp_cols = [f'pc{i+1}' for i in range(components.shape[1])]\n"
-        "df = df[[target]].join(pd.DataFrame(components, columns=comp_cols, index=df.index))"
-    )
-    state.append_pending_code(stage_name, code_snippet)
     return state

--- a/automation/agents/model_training.py
+++ b/automation/agents/model_training.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import joblib
 
 from automation.pipeline_state import PipelineState

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 scikit-learn
-openai
+openai>=1.0


### PR DESCRIPTION
## Summary
- pin `openai` to v1 in requirements
- import `os` in model training agent
- only add PCA code when PCA is recommended

## Testing
- `pip install -q -r requirements.txt`
- `python -m compileall -q automation`


------
https://chatgpt.com/codex/tasks/task_e_6877ebc5e43c83238bef5253df386ad7