### PR TITLE
Fix LLM JSON parsing and preprocessing

### DIFF
--- a/automation/agents/feature_ideation.py
+++ b/automation/agents/feature_ideation.py
@@ -7,7 +7,7 @@ from ..prompt_utils import query_llm
 def _query_llm(prompt: str) -> str:
     """Wrapper around :func:`query_llm` with no examples."""
 
-    return query_llm(prompt)
+    return query_llm(prompt, expect_json=True)
 
 
 def run(state: PipelineState) -> PipelineState:
@@ -27,6 +27,9 @@ def run(state: PipelineState) -> PipelineState:
         proposals = json.loads(llm_raw)
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"Failed to parse LLM response: {exc}") from exc
+
+    if isinstance(proposals, dict):
+        proposals = proposals.get("features", [])
 
     if not isinstance(proposals, list) or not proposals:
         raise RuntimeError("LLM did not return any feature proposals")

--- a/automation/agents/feature_implementation.py
+++ b/automation/agents/feature_implementation.py
@@ -12,7 +12,7 @@ from ..prompt_utils import query_llm
 def _query_llm(prompt: str) -> str:
     """Wrapper around :func:`query_llm` with no examples."""
 
-    return query_llm(prompt)
+    return query_llm(prompt, expect_json=True)
 
 
 def run(state: PipelineState) -> PipelineState:

--- a/automation/agents/feature_reduction.py
+++ b/automation/agents/feature_reduction.py
@@ -12,7 +12,7 @@ from sklearn.decomposition import PCA
 def _query_llm(prompt: str) -> str:
     """Wrapper around :func:`query_llm` with no examples."""
 
-    return query_llm(prompt)
+    return query_llm(prompt, expect_json=True)
 
 
 def run(state: PipelineState) -> PipelineState:

--- a/automation/agents/preprocessing.py
+++ b/automation/agents/preprocessing.py
@@ -7,7 +7,7 @@ from ..prompt_utils import query_llm
 def _query_llm(prompt: str) -> str:
     """Wrapper around :func:`query_llm` with no examples."""
 
-    return query_llm(prompt)
+    return query_llm(prompt, expect_json=True)
 
 
 def run(state: PipelineState) -> PipelineState:

--- a/automation/agents/task_identification.py
+++ b/automation/agents/task_identification.py
@@ -6,7 +6,7 @@ from ..prompt_utils import query_llm
 def _query_llm(prompt: str) -> str:
     """Wrapper around :func:`query_llm` with no examples."""
 
-    return query_llm(prompt)
+    return query_llm(prompt, expect_json=True)
 
 
 def run(state: PipelineState) -> PipelineState:

--- a/automation/prompt_utils.py
+++ b/automation/prompt_utils.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from typing import Iterable, Tuple
 import os
+import re
 
 
-def query_llm(prompt: str, few_shot: Iterable[Tuple[str, str]] | None = None) -> str:
+def query_llm(
+    prompt: str,
+    few_shot: Iterable[Tuple[str, str]] | None = None,
+    expect_json: bool = False,
+) -> str:
     """Call the OpenAI chat completion API with optional few-shot messages."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
@@ -34,11 +39,18 @@ def query_llm(prompt: str, few_shot: Iterable[Tuple[str, str]] | None = None) ->
     messages.append({"role": "user", "content": prompt})
 
     try:
-        resp = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=messages,
-            temperature=0.0,
-        )
-        return resp.choices[0].message.content.strip()
+        kwargs = {
+            "model": "gpt-3.5-turbo",
+            "messages": messages,
+            "temperature": 0.0,
+        }
+        if expect_json:
+            kwargs["response_format"] = {"type": "json_object"}
+        resp = client.chat.completions.create(**kwargs)
+        raw = resp.choices[0].message.content.strip()
+        match = re.search(r"```(?:json)?\n(.*?)```", raw, re.S)
+        if match:
+            return match.group(1).strip()
+        return raw
     except Exception as exc:  # noqa: BLE001
         raise RuntimeError(f"LLM call failed: {exc}") from exc


### PR DESCRIPTION
## Summary
- improve `query_llm` helper to support JSON mode and strip code fences
- update all agents to request JSON explicitly
- add categorical encoding and NA handling in model evaluation and training
- skip snippet scoring errors in orchestrator

## Testing
- `pytest -q`
- `python -m automation.pipeline automation/titanic.csv Survived --max-iter 1 --patience 1`

------
https://chatgpt.com/codex/tasks/task_e_6877f191e44883238d4022b234a564be