### PR TITLE
Add main function to assembled pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ built‑in heuristics.
    smarter decisions; otherwise deterministic heuristics are used.
 
    After completion you will find:
-   
+
    - `pipeline.py` – assembled code for the final pipeline
    - `output/` – directory containing logs, iteration history and a short report
+
+   The generated `pipeline.py` can be run standalone on the CSV using:
+
+   ```bash
+   python pipeline.py iris.csv target
+   ```
 
 The script prints log entries from every agent step.  Example output:
 


### PR DESCRIPTION
## Summary
- inject argparse/OS imports and a `main` function when assembling the pipeline
- append code blocks inside the new `main`
- document how to run the generated `pipeline.py` script

## Testing
- `python -m py_compile automation/code_assembler.py automation/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6878558471fc8323aae24e46484449b2