### PR TITLE
Fix requirement versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pandas
-scikit-learn
-openai>=1.0
+pandas==1.5.2
+scikit-learn==1.2.2
+openai>=0.27.0
+joblib>=1.0.0


### PR DESCRIPTION
## Summary
- pin pandas==1.5.2
- pin scikit-learn==1.2.2
- relax openai to >=0.27.0
- require joblib >=1.0.0

## Testing
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel: finished with status 'canceled')*
- `python - <<'EOF'
 import importlib
 modules=['pandas','sklearn','openai','joblib']
 for m in modules:
     try:
         importlib.import_module(m)
         print('imported', m)
     except Exception as e:
         print('failed', m, e)
 EOF`

------
https://chatgpt.com/codex/tasks/task_e_68785897e67c83238a9fc7c25a760741