### PR TITLE
Ignore duplicate feature names in feature ideation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ built‑in heuristics.
    python -m automation.pipeline iris.csv target --max-iter 15 --patience 3
    ```
 
-   The script produces a detailed log of each agent step. If the environment
-   variable `OPENAI_API_KEY` is set, the orchestrator consults the OpenAI API for
-   smarter decisions; otherwise if there is no llm access it should raise an error
-   After completion you will find:
+   The script produces a detailed log of each agent step. The pipeline checks
+   that the environment variable `OPENAI_API_KEY` is set before starting.
+   When provided the orchestrator consults the OpenAI API for smarter decisions;
+   otherwise it raises an error. After completion you will find:
 
    - `pipeline.py` – assembled code for the final pipeline
    - `output/` – directory containing logs, iteration history and a short report

--- a/automation/agents/feature_ideation.py
+++ b/automation/agents/feature_ideation.py
@@ -47,6 +47,9 @@ class Agent(BaseAgent):
             rationale = prop.get("rationale")
             if not name or not formula:
                 raise RuntimeError("LLM proposal missing 'name' or 'formula'")
+            if name in state.known_features:
+                state.append_log(f"FeatureIdeation: skip duplicate feature '{name}'")
+                continue
             state.features.append(name)
             state.known_features.add(name)
             state.feature_ideas.append({"name": name, "formula": formula, "rationale": rationale})


### PR DESCRIPTION
## Summary
- avoid logging or implementing duplicate feature names in feature ideation
- document OPENAI_API_KEY requirement in README

## Testing
- `python -m automation.pipeline --help`

------
https://chatgpt.com/codex/tasks/task_e_687893ab0ce48323907311ade6044e3c