### PR TITLE
Fix requirements for newer Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ built‑in heuristics.
 
 1. **Install the requirements**
 
+   Ensure you are using Python 3.12 or later. The project relies on
+   `openai>=1.0.0` and other modern versions of the dependencies listed in
+   `requirements.txt`.
+
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas==1.5.2
-scikit-learn==1.2.2
-openai>=0.27.0
+pandas>=2.2.0
+scikit-learn>=1.4.2
+openai>=1.0.0
 joblib>=1.0.0


### PR DESCRIPTION
## Summary
- bump pandas, scikit-learn and openai versions
- document Python/OpenAI versions in README

## Testing
- `pip install -q -r requirements.txt`
- `python - <<'EOF'
import openai, sklearn, pandas
print(openai.__version__)
print(sklearn.__version__)
print(pandas.__version__)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68789de23d98832395ed8062733019ff