### PR TITLE
Improve feature engineering and assemble code in finalcode.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ built‑in heuristics.
    When provided the orchestrator consults the OpenAI API for smarter decisions;
    otherwise it raises an error. After completion you will find:
 
-   - `pipeline.py` – assembled code for the final pipeline
+   - `finalcode.py` – assembled code for the final pipeline
    - `output/` – directory containing logs, iteration history and a short report
 
-   The generated `pipeline.py` can be run standalone on the CSV using:
+   The generated `finalcode.py` can be run standalone on the CSV using:
 
    ```bash
-   python pipeline.py iris.csv target
+   python finalcode.py iris.csv target
    ```
 
 The script prints log entries from every agent step.  Example output:

--- a/automation/agents/feature_ideation.py
+++ b/automation/agents/feature_ideation.py
@@ -52,6 +52,7 @@ class Agent(BaseAgent):
                 continue
             state.features.append(name)
             state.known_features.add(name)
+            state.feature_formulas[name] = formula
             state.feature_ideas.append({"name": name, "formula": formula, "rationale": rationale})
             state.append_log(
                 f"FeatureIdeation: propose {name} = {formula} because {rationale}"

--- a/automation/agents/feature_implementation.py
+++ b/automation/agents/feature_implementation.py
@@ -31,10 +31,16 @@ class Agent(BaseAgent):
 
         schema = {col: str(state.df[col].dtype) for col in state.df.columns}
 
+        feature_descriptions = [
+            f"{name} = {state.feature_formulas.get(name, '')}"
+            for name in state.features
+        ]
+
         base_prompt = (
             "You are a pandas expert. Given a DataFrame `df` with columns "
             f"{json.dumps(schema)}, implement the following new features: "
-            f"{state.features}. Return JSON with 'code' (Python code modifying df in"
+            f"{'; '.join(feature_descriptions)}. Avoid chained assignments and use df.loc for setting values. "
+            "Return JSON with 'code' (Python code modifying df in"
             " place) and 'logs' (one message per feature describing the action)."
         )
 

--- a/automation/agents/hyperparameter_search.py
+++ b/automation/agents/hyperparameter_search.py
@@ -43,6 +43,9 @@ class Agent(BaseAgent):
         state.append_log(
             f"HyperparameterSearch: best_params={search.best_params_} score={search.best_score_:.4f}"
         )
+        if state.best_score is None or search.best_score_ > state.best_score:
+            state.best_score = search.best_score_
+            state.current_score = search.best_score_
 
         joblib.dump(search.best_estimator_, "artifacts/model.pkl")
         code_snippet = (

--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -41,7 +41,7 @@ def compute_score(df: pd.DataFrame, target: str, task_type: str) -> float:
         X, y, test_size=0.2, random_state=42
     )
     if task_type == "classification":
-        model = LogisticRegression(max_iter=200)
+        model = LogisticRegression(max_iter=500)
         model.fit(X_train, y_train)
         preds = model.predict(X_test)
         return f1_score(y_test, preds, average="weighted")
@@ -70,7 +70,7 @@ class Agent(BaseAgent):
         )
 
         if state.task_type == "classification":
-            model = LogisticRegression(max_iter=200)
+            model = LogisticRegression(max_iter=500)
             model.fit(X_train, y_train)
             preds = model.predict(X_test)
 

--- a/automation/agents/model_training.py
+++ b/automation/agents/model_training.py
@@ -75,6 +75,9 @@ class Agent(BaseAgent):
         if model_cls is None:
             raise RuntimeError(f"Unsupported model suggested by LLM: {model_name}")
 
+        if model_cls is LogisticRegression:
+            params.setdefault("max_iter", 500)
+
         state.append_log(
             f"ModelTraining: selected {model_cls.__name__} with params {params}"
         )

--- a/automation/agents/preprocessing.py
+++ b/automation/agents/preprocessing.py
@@ -29,6 +29,7 @@ class Agent(BaseAgent):
             "Given a pandas DataFrame `df` with schema "
             f"{json.dumps(schema)} and missing counts {json.dumps(missing)}, "
             "suggest preprocessing steps for machine learning. "
+            "Avoid chained assignments; use df.loc for setting values. "
             "Return JSON with keys 'logs' (list of messages describing each step) "
             "and 'code' (Python pandas code that modifies df in place)."
         )

--- a/automation/code_assembler.py
+++ b/automation/code_assembler.py
@@ -60,7 +60,7 @@ def run(state: PipelineState) -> PipelineState:
         "    main()",
     ])
 
-    with open("pipeline.py", "w") as f:
+    with open("finalcode.py", "w") as f:
         f.write("\n".join(lines))
 
     with open("output/logs.json", "w") as f:

--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -10,6 +10,7 @@ class PipelineState:
     iterate: bool = False
     log: List[str] = field(default_factory=list)
     features: List[str] = field(default_factory=list)
+    feature_formulas: dict[str, str] = field(default_factory=dict)
     feature_ideas: list[dict] = field(default_factory=list)
     known_features: set[str] = field(default_factory=set)
     pending_code: dict[str, list[str]] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- store feature formulas in `PipelineState`
- pass formulas to `feature_implementation` prompts and retry on failure
- avoid chained assignment in preprocessing prompts
- bump logistic regression iterations
- inject default `max_iter` when training logistic regression models
- update hyperparameter search to track best score
- write assembled pipeline to `finalcode.py`
- update documentation for new output file

## Testing
- `pip install -q -r requirements.txt`
- `python -m automation.pipeline automation/titanic.csv Survived --max-iter 1 --patience 1` *(fails: invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_6879e136dc8083238c8a2d3de24e418f