### PR TITLE
Enable unlimited iterations with patience

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project provides an agentic, LLM-driven data science pipeline that automate
 ## Features
 - Upload your own CSV dataset
 - Select the target column
-- Set patience (early stopping rounds)
+- Set patience (number of rounds without improvement before stopping; default 20)
 - Run the pipeline with a single click
 - View the final model score (accuracy or F1)
 - Download or copy the final assembled code for reproducibility
@@ -26,7 +26,7 @@ streamlit run streamlit_app.py
 - Open [http://localhost:8501](http://localhost:8501) in your browser.
 - **Upload** your CSV file.
 - **Select** the target column from the dropdown.
-- **Set** the patience value (number of rounds with no improvement before stopping).
+- **Set** the patience value (number of rounds with no improvement before stopping, default 20).
 - **Click** "Run Pipeline".
 - **View** the final model score (accuracy or F1) and the full assembled code.
 
@@ -42,7 +42,7 @@ streamlit run streamlit_app.py
 ## Advanced Usage
 - You can still run the pipeline from the command line:
   ```bash
-  python run_agentic_pipeline.py <csv_path> <target_column> --patience <patience>
+  python run_agentic_pipeline.py <csv_path> <target_column> --patience 20
   ```
 - All outputs and logs are saved in the `output/` directory.
 

--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -107,10 +107,7 @@ class Agent(BaseAgent):
         else:
             state.no_improve_rounds += 1
 
-        state.iterate = not (
-            state.no_improve_rounds >= state.patience
-            or state.iteration >= state.max_iter
-        )
+        state.iterate = state.no_improve_rounds < state.patience
 
         log_msg = f"ModelEvaluation decision: iterate={state.iterate} (hardcoded logic)"
         state.append_log(log_msg)

--- a/automation/pipeline.py
+++ b/automation/pipeline.py
@@ -8,7 +8,7 @@ from automation.pipeline_state import PipelineState
 from automation.agents import orchestrator
 
 
-def run_pipeline(csv_path: str, target: str, max_iter: int = 10, patience: int = 5, score_threshold: float = 0.80) -> PipelineState:
+def run_pipeline(csv_path: str, target: str, patience: int = 20, score_threshold: float = 0.80) -> PipelineState:
     """Load data, initialize :class:`PipelineState`, and run the orchestrator."""
 
     if not os.getenv("OPENAI_API_KEY"):
@@ -16,7 +16,7 @@ def run_pipeline(csv_path: str, target: str, max_iter: int = 10, patience: int =
 
     df = pd.read_csv(csv_path)
     state = PipelineState(df=df, target=target)
-    return orchestrator.run(state, max_iter=max_iter, patience=patience, score_threshold=score_threshold)
+    return orchestrator.run(state, patience=patience, score_threshold=score_threshold)
 
 
 def compile_log(state: PipelineState) -> str:
@@ -37,11 +37,10 @@ def main(args: list[str] | None = None) -> None:
     )
     parser.add_argument("csv", help="Path to CSV file")
     parser.add_argument("target", help="Target column name")
-    parser.add_argument("--max-iter", type=int, default=10, help="Maximum iterations")
-    parser.add_argument("--patience", type=int, default=5, help="Rounds without improvement before stopping")
+    parser.add_argument("--patience", type=int, default=20, help="Rounds without improvement before stopping")
     parser.add_argument("--score-threshold", type=float, default=0.80, help="Score threshold to trigger hyperparameter search")
     parsed = parser.parse_args(args)
-    final_state = run_pipeline(parsed.csv, parsed.target, max_iter=parsed.max_iter, patience=parsed.patience, score_threshold=parsed.score_threshold)
+    final_state = run_pipeline(parsed.csv, parsed.target, patience=parsed.patience, score_threshold=parsed.score_threshold)
     print_final_log(final_state)
 
 

--- a/run_agentic_pipeline.py
+++ b/run_agentic_pipeline.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     df = pd.read_csv(csv_path)
     state = PipelineState(df=df, target=target)
     try:
-        final_state = run(state)
+        final_state = run(state, patience=20)
     finally:
         # Always assemble code, even on error
         code_assembler.run(state)
@@ -21,4 +21,6 @@ if __name__ == "__main__":
     # Print iteration history for accuracy/score progression
     print("\nIteration History (score progression):")
     for entry in final_state.iteration_history:
-        print(f"Iteration {entry['iteration']}: score={entry.get('best_score', 'N/A')}, metrics={entry.get('metrics', '')}") 
+        print(
+            f"Iteration {entry['iteration']}: score={entry.get('best_score', 'N/A')}, metrics={entry.get('metrics', '')}"
+        )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -17,7 +17,7 @@ if uploaded_file is not None:
     # 2. Target column selector
     target = st.selectbox('Select target column', df.columns)
     # 3. Patience input
-    patience = st.number_input('Set patience (early stopping rounds)', min_value=1, max_value=100, value=10)
+    patience = st.number_input('Set patience (early stopping rounds)', min_value=1, max_value=100, value=20)
     # 4. Run button
     if st.button('Run Pipeline'):
         # Save uploaded file to a temp location


### PR DESCRIPTION
## Summary
- allow orchestrator to run indefinitely until no improvements are seen for 20 rounds
- adjust model evaluation early-stopping logic
- simplify CLI and pipeline defaults
- update example runner and streamlit defaults
- document new behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687f34fc8c448323b96d15ead1a7ad1f