### PR TITLE
Fix evaluation loop by switching to random forest

### DIFF
--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -17,7 +17,8 @@ from sklearn.metrics import (
     mean_squared_error,
     r2_score,
 )
-from sklearn.linear_model import LogisticRegression, LinearRegression
+from sklearn.linear_model import LinearRegression
+from sklearn.ensemble import RandomForestClassifier
 
 __all__ = ["compute_score", "run"]
 
@@ -41,7 +42,7 @@ def compute_score(df: pd.DataFrame, target: str, task_type: str) -> float:
         X, y, test_size=0.2, random_state=42
     )
     if task_type == "classification":
-        model = LogisticRegression(max_iter=500)
+        model = RandomForestClassifier(n_estimators=100, random_state=42)
         model.fit(X_train, y_train)
         preds = model.predict(X_test)
         return f1_score(y_test, preds, average="weighted")
@@ -70,7 +71,7 @@ class Agent(BaseAgent):
         )
 
         if state.task_type == "classification":
-            model = LogisticRegression(max_iter=500)
+            model = RandomForestClassifier(n_estimators=100, random_state=42)
             model.fit(X_train, y_train)
             preds = model.predict(X_test)
 

--- a/automation/agents/orchestrator.py
+++ b/automation/agents/orchestrator.py
@@ -7,7 +7,6 @@ from typing import Dict, cast
 
 import pandas as pd
 from sklearn.decomposition import PCA
-from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from automation.pipeline_state import PipelineState


### PR DESCRIPTION
## Summary
- avoid getting stuck in LogisticRegression by using RandomForestClassifier for quick scoring
- drop unused LogisticRegression import from orchestrator

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pip install xgboost`
- `python - <<'EOF'
import pandas as pd
from sklearn.datasets import load_iris
from automation.pipeline_state import PipelineState
from automation.agents.orchestrator import run
iris = load_iris()
df = pd.DataFrame(iris.data, columns=iris.feature_names)
df['target'] = iris.target
state = PipelineState(df=df, target='target')
final = run(state, patience=3)
print('best_score:', final.best_score)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687f3b5d0f988323b387866eb3000ea7