### PR TITLE
Add robust LLM querying with retries and schema validation

### DIFF
--- a/automation/agents/correlation_eda.py
+++ b/automation/agents/correlation_eda.py
@@ -62,7 +62,11 @@ class Agent(BaseAgent):
             f"Outlier counts: {outlier_counts}"
         )
 
-        summary = _query_llm(prompt)
+        try:
+            summary = _query_llm(prompt)
+        except RuntimeError as exc:
+            state.append_log(f"CorrelationEDA: LLM query failed: {exc}")
+            return state
         if not summary:
             raise RuntimeError("LLM did not return a summary for correlation EDA")
         state.append_log(f"CorrelationEDA: {summary}")

--- a/automation/agents/feature_reduction.py
+++ b/automation/agents/feature_reduction.py
@@ -50,7 +50,11 @@ class Agent(BaseAgent):
             "Respond in JSON with keys 'apply_pca' (yes/no) and 'reason'."
         )
 
-        llm_raw = _query_llm(prompt)
+        try:
+            llm_raw = _query_llm(prompt)
+        except RuntimeError as exc:
+            state.append_log(f"FeatureReduction: LLM query failed: {exc}")
+            return state
         try:
             parsed = json.loads(llm_raw)
         except Exception as exc:  # noqa: BLE001

--- a/automation/agents/model_training.py
+++ b/automation/agents/model_training.py
@@ -72,7 +72,11 @@ class Agent(BaseAgent):
             f"{X.shape[1]} features. Respond in JSON with keys 'model' and 'params'."
         )
 
-        llm_raw = _query_llm(prompt)
+        try:
+            llm_raw = _query_llm(prompt)
+        except RuntimeError as exc:
+            state.append_log(f"ModelTraining: LLM query failed: {exc}")
+            return state
         try:
             parsed = json.loads(llm_raw)
         except Exception as exc:  # noqa: BLE001

--- a/automation/agents/preprocessing.py
+++ b/automation/agents/preprocessing.py
@@ -73,7 +73,11 @@ class Agent(BaseAgent):
             "{\n  'logs': [\n    'Filled 2 missing values in column A with mean.',\n    'Column B is binary categorical, encoded as ordinal (0/1).',\n    'Column D is high-cardinality categorical, encoded with frequency encoding.',\n    'Filled 1 missing value in column D with mode.'\n  ],\n  'code': \"df['A'] = df['A'].fillna(df['A'].mean())\\ndf['B'] = df['B'].astype('category').cat.codes\\ndf['D'] = df['D'].map(df['D'].value_counts())\\ndf['D'] = df['D'].fillna(df['D'].mode()[0])\",\n  'rationale': 'Numeric columns: mean imputation. Binary categoricals: ordinal encoding. High-cardinality categoricals: frequency encoding. All steps logged.'\n}\n"
             "---\nNow, using the provided schema, missing, unique_counts, and must_keep, produce your JSON response."
         )
-        llm_resp = _query_llm(base_prompt)
+        try:
+            llm_resp = _query_llm(base_prompt)
+        except RuntimeError as exc:
+            state.append_log(f"Preprocessing: LLM query failed: {exc}")
+            return state
         try:
             parsed = json.loads(llm_resp)
         except json.JSONDecodeError as exc:

--- a/automation/agents/task_identification.py
+++ b/automation/agents/task_identification.py
@@ -30,7 +30,11 @@ class Agent(BaseAgent):
             f"Stats: {json.dumps(stats, default=str)}"
         )
 
-        llm_raw = _query_llm(prompt)
+        try:
+            llm_raw = _query_llm(prompt)
+        except RuntimeError as exc:
+            state.append_log(f"TaskIdentification: LLM query failed: {exc}")
+            return state
         try:
             parsed = json.loads(llm_raw)
         except json.JSONDecodeError as exc:

--- a/automation/prompt_utils.py
+++ b/automation/prompt_utils.py
@@ -3,14 +3,38 @@ from __future__ import annotations
 from typing import Iterable, Tuple
 import os
 import re
+import time
+import json
 
 
 def query_llm(
     prompt: str,
     few_shot: Iterable[Tuple[str, str]] | None = None,
     expect_json: bool = False,
+    *,
+    timeout: float | None = 30.0,
+    max_retries: int = 3,
+    json_schema: dict | None = None,
 ) -> str:
-    """Call the OpenAI chat completion API with optional few-shot messages."""
+    """Call the OpenAI chat completion API with optional few-shot messages.
+
+    Parameters
+    ----------
+    prompt:
+        The user prompt to send to the LLM.
+    few_shot:
+        Optional list of (user, assistant) message tuples to include as
+        examples.
+    expect_json:
+        If ``True``, request a JSON-formatted response from the LLM.
+    timeout:
+        Request timeout in seconds passed to the OpenAI client.
+    max_retries:
+        Number of attempts before giving up.
+    json_schema:
+        Optional JSON schema to validate the response against. Requires the
+        ``jsonschema`` package if supplied.
+    """
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("OPENAI_API_KEY environment variable is required")
@@ -18,6 +42,16 @@ def query_llm(
         import openai
     except Exception as exc:  # noqa: BLE001
         raise RuntimeError("openai package is required") from exc
+
+    if json_schema is not None:
+        try:
+            import jsonschema  # noqa: WPS433 -- optional dependency
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                "jsonschema package is required for validation"
+            ) from exc
+    else:
+        jsonschema = None  # type: ignore
 
     client = openai.OpenAI(api_key=api_key)
 
@@ -38,19 +72,39 @@ def query_llm(
 
     messages.append({"role": "user", "content": prompt})
 
-    try:
-        kwargs = {
-            "model": "gpt-3.5-turbo",
-            "messages": messages,
-            "temperature": 0.0,
-        }
-        if expect_json:
-            kwargs["response_format"] = {"type": "json_object"}
-        resp = client.chat.completions.create(**kwargs)
-        raw = resp.choices[0].message.content.strip()
-        match = re.search(r"```(?:json)?\n(.*?)```", raw, re.S)
-        if match:
-            return match.group(1).strip()
-        return raw
-    except Exception as exc:  # noqa: BLE001
-        raise RuntimeError(f"LLM call failed: {exc}") from exc
+    kwargs = {
+        "model": "gpt-3.5-turbo",
+        "messages": messages,
+        "temperature": 0.0,
+        "timeout": timeout,
+    }
+    if expect_json:
+        kwargs["response_format"] = {"type": "json_object"}
+
+    for attempt in range(max_retries):
+        try:
+            resp = client.chat.completions.create(**kwargs)
+            raw = resp.choices[0].message.content.strip()
+            match = re.search(r"```(?:json)?\n(.*?)```", raw, re.S)
+            if match:
+                raw = match.group(1).strip()
+            if json_schema is not None and jsonschema is not None:
+                try:
+                    parsed = json.loads(raw)
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        f"LLM response JSON parse failed: {exc}"
+                    ) from exc
+                try:
+                    jsonschema.validate(instance=parsed, schema=json_schema)
+                except jsonschema.ValidationError as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        f"LLM response failed validation: {exc.message}"
+                    ) from exc
+            return raw
+        except Exception as exc:  # noqa: BLE001
+            if attempt == max_retries - 1:
+                raise RuntimeError(
+                    f"LLM call failed after {max_retries} attempts: {exc}"
+                ) from exc
+            time.sleep(2 ** attempt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas>=2.2.0
 scikit-learn>=1.4.2
 openai>=1.0.0
+jsonschema>=4.17
 joblib>=1.0.0


### PR DESCRIPTION
## Summary
- enhance `query_llm` with timeout, retries, and optional JSON schema validation
- catch failed retries in agents and log the error
- install `jsonschema` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688093ccc25c832399b1226af8efe4a3