### PR TITLE
Add dataset profiling to PipelineState

### DIFF
--- a/automation/pipeline.py
+++ b/automation/pipeline.py
@@ -4,6 +4,8 @@ import argparse
 import pandas as pd
 import os
 
+from automation.dataset_profiler import EnhancedDatasetProfiler
+
 from automation.pipeline_state import PipelineState
 from automation.agents import orchestrator
 
@@ -16,6 +18,7 @@ def run_pipeline(csv_path: str, target: str, patience: int = 20, score_threshold
 
     df = pd.read_csv(csv_path)
     state = PipelineState(df=df, target=target)
+    state.profile = EnhancedDatasetProfiler.generate_comprehensive_profile(df, target)
     return orchestrator.run(state, patience=patience, score_threshold=score_threshold)
 
 

--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 import pandas as pd
 
 @dataclass
@@ -23,6 +23,7 @@ class PipelineState:
     best_code_blocks: dict[str, list[str]] = field(default_factory=dict)
     best_features: List[str] = field(default_factory=list)
     best_params: dict[str, object] = field(default_factory=dict)
+    profile: Optional[Dict[str, Any]] = None
     patience: int = 5
     no_improve_rounds: int = 0
     iteration: int = 0
@@ -80,6 +81,7 @@ class PipelineState:
                 k: v.copy() for k, v in self.best_code_blocks.items()
             },
             "best_features": list(self.best_features),
+            "profile": self.profile.copy() if isinstance(self.profile, dict) else self.profile,
         }
         return self._version
 
@@ -102,3 +104,8 @@ class PipelineState:
             k: v.copy() for k, v in snapshot["best_code_blocks"].items()
         }
         self.best_features = list(snapshot["best_features"])
+        self.profile = (
+            snapshot.get("profile").copy()
+            if isinstance(snapshot.get("profile"), dict)
+            else snapshot.get("profile")
+        )


### PR DESCRIPTION
## Summary
- allow persisting dataset profile in `PipelineState`
- compute profile on pipeline startup using `EnhancedDatasetProfiler`

## Testing
- `python3 -m py_compile automation/pipeline_state.py automation/pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6880a99a17b483239337c62f16ca593a