### PR TITLE
Run pipeline with Kaggle data

### DIFF
--- a/automation/agents/orchestrator.py
+++ b/automation/agents/orchestrator.py
@@ -224,32 +224,6 @@ class Orchestrator:
         return state
 
 
-def is_model_ready(df, target):
-    """Return ``True`` if all features (except the target) are numeric and have no
-    missing values."""
-
-    import numpy as np
-
-    X = df.drop(columns=[target])
-    # ``exclude=[np.number]`` covers all numeric dtypes (int8, int16, float32, etc.)
-    non_numeric = X.select_dtypes(exclude=[np.number])
-    return non_numeric.empty and not X.isnull().any().any()
-
-def try_model_training(df, target, task_type):
-    from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-    X = df.drop(columns=[target])
-    y = df[target]
-    try:
-        if task_type == 'classification':
-            model = RandomForestClassifier(n_estimators=10, random_state=42)
-        else:
-            model = RandomForestRegressor(n_estimators=10, random_state=42)
-        model.fit(X, y)
-        return True
-    except Exception:
-        return False
-
-
     def run_pipeline(self, state: PipelineState, patience: int = 20, score_threshold: float = 0.80) -> PipelineState:
         """Run the pipeline with LLM-guided orchestration and iteration."""
         state.append_log("Orchestrator supervisor: booting pipeline")
@@ -347,6 +321,34 @@ def try_model_training(df, target, task_type):
         pprint.pprint(state.code_blocks.get('feature_selection', []))
         state = code_assembler.run(state)
         return state
+
+
+def is_model_ready(df, target):
+    """Return ``True`` if all features (except the target) are numeric and have no
+    missing values."""
+
+    import numpy as np
+
+    X = df.drop(columns=[target])
+    # ``exclude=[np.number]`` covers all numeric dtypes (int8, int16, float32, etc.)
+    non_numeric = X.select_dtypes(exclude=[np.number])
+    return non_numeric.empty and not X.isnull().any().any()
+
+def try_model_training(df, target, task_type):
+    from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+    X = df.drop(columns=[target])
+    y = df[target]
+    try:
+        if task_type == 'classification':
+            model = RandomForestClassifier(n_estimators=10, random_state=42)
+        else:
+            model = RandomForestRegressor(n_estimators=10, random_state=42)
+        model.fit(X, y)
+        return True
+    except Exception:
+        return False
+
+
 
 
 def run(state: PipelineState, patience: int = 20, score_threshold: float = 0.80) -> PipelineState:

--- a/automation/dataset_profiler.py
+++ b/automation/dataset_profiler.py
@@ -15,7 +15,7 @@ class EnhancedDatasetProfiler:
     ) -> Dict[str, Any]:
         """Return a rich profiling summary for the given dataframe."""
         profile: Dict[str, Any] = {}
-        profile["statistical_summary"] = df.describe(include="all", datetime_is_numeric=True).to_dict()
+        profile["statistical_summary"] = df.describe(include="all").to_dict()
         profile["missing_patterns"] = cls._analyze_missing_patterns(df)
         profile["outlier_detection"] = cls._detect_outliers(df)
         profile["skewness"] = (


### PR DESCRIPTION
## Summary
- fix orchestrator `run_pipeline` indentation so the method is part of the class
- update dataset profiler to drop `datetime_is_numeric` arg for pandas 2.3
- run the pipeline on a Kaggle weather dataset

## Testing
- `python -m py_compile automation/agents/orchestrator.py`
- `python -m py_compile automation/dataset_profiler.py`
- `python run_agentic_pipeline.py data/Weather_dataset.csv temperature > output.log 2>&1 && tail -n 20 output.log`

------
https://chatgpt.com/codex/tasks/task_e_6881ee274de083239be423c7194f5aac