### PR TITLE
Improve orchestrator logging and log output

### DIFF
--- a/automation/agents/orchestrator.py
+++ b/automation/agents/orchestrator.py
@@ -138,6 +138,7 @@ class Orchestrator:
         prev_best_score = state.best_score if state.best_score is not None else state.current_score
 
         decisions = self._decide_steps(state)
+        state.append_log(f"Orchestrator: step decisions {decisions}")
 
         if decisions.get("preprocessing", {}).get("run", True):
             state = self.STEP_AGENTS["preprocessing"].run(state)
@@ -310,16 +311,21 @@ class Orchestrator:
                 state.append_log(
                     "Hyperparameter search skipped after iterations (algorithms not recommended)."
                 )
-        import pprint
-        print("[DEBUG] state.pending_code['feature_implementation']:")
-        pprint.pprint(state.pending_code.get('feature_implementation', []))
-        print("[DEBUG] state.code_blocks['feature_implementation']:")
-        pprint.pprint(state.code_blocks.get('feature_implementation', []))
-        print("[DEBUG] state.pending_code['feature_selection']:")
-        pprint.pprint(state.pending_code.get('feature_selection', []))
-        print("[DEBUG] state.code_blocks['feature_selection']:")
-        pprint.pprint(state.code_blocks.get('feature_selection', []))
+        state.append_log(
+            "Iteration summary: pending feature_implementation="
+            f"{len(state.pending_code.get('feature_implementation', []))}, "
+            f"pending feature_selection={len(state.pending_code.get('feature_selection', []))}"
+        )
+        state.append_log(
+            "Current accepted snippets: feature_implementation="
+            f"{len(state.code_blocks.get('feature_implementation', []))}, "
+            f"feature_selection={len(state.code_blocks.get('feature_selection', []))}"
+        )
+        state.append_log(f"Best score so far: {state.best_score}")
         state = code_assembler.run(state)
+        state.append_log(
+            f"Orchestrator finished after {state.iteration} iterations with best score {state.best_score}"
+        )
         return state
 
 

--- a/automation/pipeline.py
+++ b/automation/pipeline.py
@@ -43,8 +43,15 @@ def main(args: list[str] | None = None) -> None:
     parser.add_argument("--patience", type=int, default=20, help="Rounds without improvement before stopping")
     parser.add_argument("--score-threshold", type=float, default=0.80, help="Score threshold to trigger hyperparameter search")
     parsed = parser.parse_args(args)
-    final_state = run_pipeline(parsed.csv, parsed.target, patience=parsed.patience, score_threshold=parsed.score_threshold)
+    final_state = run_pipeline(
+        parsed.csv,
+        parsed.target,
+        patience=parsed.patience,
+        score_threshold=parsed.score_threshold,
+    )
     print_final_log(final_state)
+    final_state.write_log("output/pipeline.log")
+    print("Logs written to output/pipeline.log")
 
 
 if __name__ == "__main__":

--- a/automation/pipeline_state.py
+++ b/automation/pipeline_state.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any
+import os
 import pandas as pd
 
 @dataclass
@@ -120,3 +121,9 @@ class PipelineState:
         self.recommended_algorithms = list(snapshot.get("recommended_algorithms", []))
         self.timeseries_mode = snapshot.get("timeseries_mode", False)
         self.time_col = snapshot.get("time_col")
+
+    def write_log(self, file_path: str) -> None:
+        """Persist the current log to ``file_path``."""
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "w") as f:
+            f.write("\n".join(self.log))

--- a/run_agentic_pipeline.py
+++ b/run_agentic_pipeline.py
@@ -12,11 +12,13 @@ if __name__ == "__main__":
     target = sys.argv[2]
     df = pd.read_csv(csv_path)
     state = PipelineState(df=df, target=target)
+    final_state = state
     try:
         final_state = run(state, patience=20)
     finally:
         # Always assemble code, even on error
-        code_assembler.run(state)
+        code_assembler.run(final_state)
+        final_state.write_log("output/pipeline.log")
     print("Agentic pipeline completed. Check logs and output for results.")
     # Print iteration history for accuracy/score progression
     print("\nIteration History (score progression):")
@@ -24,3 +26,4 @@ if __name__ == "__main__":
         print(
             f"Iteration {entry['iteration']}: score={entry.get('best_score', 'N/A')}, metrics={entry.get('metrics', '')}"
         )
+    print("Logs written to output/pipeline.log")


### PR DESCRIPTION
## Summary
- extend `PipelineState` with `write_log` helper
- save pipeline logs to `output/pipeline.log` when running from CLI scripts
- record orchestrator decisions and iteration summaries in the logs

## Testing
- `pip install -r requirements.txt`
- `python -m automation.pipeline --help`
- `python run_agentic_pipeline.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688209a2f46083238eeb358c1cb14c41