### PR TITLE
Implement generic CodeExecutionTool

### DIFF
--- a/automation/tools/__init__.py
+++ b/automation/tools/__init__.py
@@ -3,6 +3,7 @@ from ..time_aware_splitter import TimeAwareSplitter
 from ..temporal_feature_engineer import TemporalFeatureEngineer
 from ..timeseries_detection import TimeseriesDetectionUtility
 from .code_execution_tool import (
+    CodeExecutionTool,
     execute_preprocessing_code,
     execute_feature_engineering_code,
     test_model_performance,
@@ -13,6 +14,7 @@ __all__ = [
     "TimeAwareSplitter",
     "TemporalFeatureEngineer",
     "TimeseriesDetectionUtility",
+    "CodeExecutionTool",
     "execute_preprocessing_code",
     "execute_feature_engineering_code",
     "test_model_performance",


### PR DESCRIPTION
## Summary
- introduce `CodeExecutionTool.execute_code` for sandboxed execution
- export `CodeExecutionTool` in tools package

## Testing
- `python -m py_compile automation/tools/code_execution_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_68837f2859ec8323b9246b4c8afde97f