### PR TITLE
Add asynchronous pipeline test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ xgboost>=1.7.0
 lightgbm>=3.3.5
 streamlit>=1.26.0
 python-dotenv>=1.0.0
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main_pipeline import DataSciencePipeline
+from automation.pipeline_state import PipelineState
+
+
+@pytest.mark.asyncio
+async def test_async_pipeline_run(monkeypatch):
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "target": [0, 1, 0]})
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as tmp:
+        df.to_csv(tmp.name, index=False)
+        csv_path = tmp.name
+
+    def fake_run(state: PipelineState):
+        state.best_score = 0.42
+        return state
+
+    def fake_assemble(state: PipelineState):
+        return state
+
+    monkeypatch.setattr("automation.agents.orchestrator.run", fake_run)
+    monkeypatch.setattr("automation.code_assembler.run", fake_assemble)
+
+    pipeline = DataSciencePipeline(csv_path, "target")
+    final = await pipeline.run()
+
+    os.remove(csv_path)
+    assert final.score == 0.42


### PR DESCRIPTION
## Summary
- add pytest and pytest-asyncio to requirements
- create `tests/test_pipeline.py` with async test for `DataSciencePipeline`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688382fa4be88323a96a77dd4d6f4b0c