### PR TITLE
Improve debug logging of orchestration decisions

### DIFF
--- a/automation/agents/model_evaluation.py
+++ b/automation/agents/model_evaluation.py
@@ -140,8 +140,15 @@ class ModelEvaluationAgent(BaseAgent):
         if improved:
             state.best_score = new_score
             state.no_improve_rounds = 0
+            delta = new_score - (prev_best or 0.0)
+            state.append_log(
+                f"ModelEvaluation: score improved by {delta:.4f} to {new_score:.4f}"
+            )
         else:
             state.no_improve_rounds += 1
+            state.append_log(
+                f"ModelEvaluation: no improvement (score {new_score:.4f})"
+            )
 
         state.iterate = state.no_improve_rounds < state.patience
 


### PR DESCRIPTION
## Summary
- add detailed logs to show how accepted snippets change the score
- record post-evaluation score deltas
- log when ModelEvaluation improves or stalls

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883910195f0832382c5d605ac19c6d3